### PR TITLE
Upgrade to Lucene 4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     </parent>
 
     <properties>
-        <elasticsearch.version>0.19.3</elasticsearch.version>
+        <elasticsearch.version>0.21.0.Beta1-SNAPSHOT</elasticsearch.version>
     </properties>
 
     <repositories>
@@ -51,8 +51,8 @@
 
         <dependency>
             <groupId>org.apache.lucene</groupId>
-            <artifactId>lucene-icu</artifactId>
-            <version>3.6.1</version>
+            <artifactId>lucene-analyzers-icu</artifactId>
+            <version>4.1.0</version>
             <scope>compile</scope>
         </dependency>
 

--- a/src/test/java/org/elasticsearch/index/analysis/SimpleIcuCollationTokenFilterTests.java
+++ b/src/test/java/org/elasticsearch/index/analysis/SimpleIcuCollationTokenFilterTests.java
@@ -3,7 +3,7 @@ package org.elasticsearch.index.analysis;
 import com.ibm.icu.text.Collator;
 import com.ibm.icu.text.RuleBasedCollator;
 import com.ibm.icu.util.ULocale;
-import org.apache.lucene.analysis.KeywordTokenizer;
+import org.apache.lucene.analysis.core.KeywordTokenizer;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.elasticsearch.common.inject.Injector;


### PR DESCRIPTION
I used ElasticSearch `0.21.0.Beta1-SNAPSHOT` for now, at it is the only Lucene 4+ ES version available.
